### PR TITLE
visit count not available anymore in WebHistory

### DIFF
--- a/Stainless/StainlessServer.h
+++ b/Stainless/StainlessServer.h
@@ -91,6 +91,7 @@ enum {
 
 	BOOL webHistoryCanRecordVisits;
 	BOOL webHistoryCanControlVisitCount;
+	BOOL webHistoryHasVisitCount;
 }
 
 @property(nonatomic, retain) NSString* ignoreHistory;

--- a/Stainless/StainlessServer.m
+++ b/Stainless/StainlessServer.m
@@ -182,6 +182,7 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 
 	webHistoryCanRecordVisits = NO;
 	webHistoryCanControlVisitCount = NO;
+	webHistoryHasVisitCount = NO;
 	
 	WebHistoryItem* entry = [[WebHistoryItem alloc] initWithURLString:@"" title:@"" lastVisitedTimeInterval:[NSDate timeIntervalSinceReferenceDate]];
 	if([entry respondsToSelector:@selector(_recordInitialVisit)]) {
@@ -192,6 +193,8 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 		else if([entry respondsToSelector:@selector(_visitedWithTitle:)])
 			webHistoryCanRecordVisits = YES;
 	}
+	if([entry respondsToSelector:@selector(visitCount)])
+		webHistoryHasVisitCount = YES;
 	[entry release];
 		
 	[self refreshHistory];
@@ -2110,7 +2113,7 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 		
 		if(webHistoryCanRecordVisits)
 			[entry _recordInitialVisit];
-		else if(webHistoryCanControlVisitCount)
+		else if(webHistoryHasVisitCount)
 			[entry setVisitCount:1];
 			
 		[clientHistory addItems:[NSArray arrayWithObject:entry]];
@@ -2248,7 +2251,8 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 		[searchComplete swap];
 		
 		NSMutableArray* matches = [searchComplete arrayOfDataMatchingString:urlString];
-		[matches sortUsingSelector:@selector(visitCountCompare:)];
+		if(webHistoryHasVisitCount)
+			[matches sortUsingSelector:@selector(visitCountCompare:)];
 		for(WebHistoryItem* item in matches) {
 			NSString* alternateTitle = [item alternateTitle];
 			if(alternateTitle) {
@@ -2273,7 +2277,8 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 			completion = [NSMutableArray arrayWithCapacity:maxCount];
 		
 		NSMutableArray* matches = [urlComplete arrayOfDataMatchingString:urlString];
-		[matches sortUsingSelector:@selector(visitCountCompare:)];
+		if(webHistoryHasVisitCount)
+			[matches sortUsingSelector:@selector(visitCountCompare:)];
 		for(WebHistoryItem* item in matches) {
 			NSString* itemURLString = [item URLString];
 			

--- a/Stainless/StainlessServer.m
+++ b/Stainless/StainlessServer.m
@@ -2110,7 +2110,7 @@ void processNotificationCallback(CGSNotificationType type, void* data, unsigned 
 		
 		if(webHistoryCanRecordVisits)
 			[entry _recordInitialVisit];
-		else
+		else if(webHistoryCanControlVisitCount)
 			[entry setVisitCount:1];
 			
 		[clientHistory addItems:[NSArray arrayWithObject:entry]];


### PR DESCRIPTION
Current WebKit sources don't respond to setVisitCount any longer so it throws an exception and Stainless history doesn't work.
Seems that just this little check has been missing.
